### PR TITLE
Add explicit source link handling for posts

### DIFF
--- a/app/common/gpt_utils.py
+++ b/app/common/gpt_utils.py
@@ -1,4 +1,5 @@
 import json
+from html import escape
 from typing import List, Dict
 
 from openai import OpenAI
@@ -95,7 +96,8 @@ def build_post(item: Dict[str, str], tone: str) -> Dict[str, str]:
       "body_markdown": "...",
       "cynical_comment": "...",
       "meme_prompt": "...",
-      "meme_alt_text": "..."
+      "meme_alt_text": "...",
+      "source_link_text": "..."
     }
     """
 
@@ -119,10 +121,11 @@ def build_post(item: Dict[str, str], tone: str) -> Dict[str, str]:
 
 {{
   "title": "블로그용 제목",
-  "body_markdown": "3~6줄 정도의 요약. Markdown 형식 가능. 원문 링크도 포함.",
+  "body_markdown": "3~6줄 정도의 요약. Markdown 형식 가능. 원문 링크는 넣지 말고 본문만",
   "cynical_comment": "짧고 임팩트 있는 시니컬 코멘트 1줄",
   "meme_prompt": "이 뉴스에 어울리는 밈 이미지 설명 (AI 이미지 생성용)",
-  "meme_alt_text": "ALT 텍스트"
+  "meme_alt_text": "ALT 텍스트",
+  "source_link_text": "원문 링크용 앵커 텍스트 (간결하게)"
 }}
 """
 
@@ -136,3 +139,23 @@ def build_post(item: Dict[str, str], tone: str) -> Dict[str, str]:
     data = json.loads(raw)
 
     return data
+
+
+def append_source_link(body_markdown: str, source_url: str, link_text: str = "원문 보기") -> str:
+    """
+    본문 마크다운에 원문 링크 HTML 블록을 덧붙인다.
+    - body_markdown: GPT가 생성한 본문(링크 없음)
+    - source_url: 원문 URL
+    - link_text: 앵커 텍스트(없으면 기본값)
+    """
+
+    if not source_url:
+        return body_markdown
+
+    safe_url = escape(source_url, quote=True)
+    safe_text = escape(link_text or "원문 보기")
+    source_block = f'<p><strong>원문:</strong> <a href="{safe_url}">{safe_text}</a></p>'
+
+    if body_markdown.strip():
+        return f"{body_markdown}\n\n{source_block}"
+    return source_block

--- a/app/jobs/job_game_news.py
+++ b/app/jobs/job_game_news.py
@@ -60,9 +60,15 @@ def run():
         print(f"[GAME] Meme image generated at {image_path}")
 
     # 7. 워드프레스에 글 발행
+    body_with_source = gpt_utils.append_source_link(
+        body_markdown=post_data["body_markdown"],
+        source_url=picked["url"],
+        link_text=post_data.get("source_link_text", "원문 보기"),
+    )
+
     wp_client.create_post(
         title=post_data["title"],
-        body_markdown=post_data["body_markdown"],
+        body_markdown=body_with_source,
         cynical_comment=post_data["cynical_comment"],
         meme_media_id=media_id,
         category_id=WP_CATEGORY_GAME,

--- a/app/jobs/job_kr_tech.py
+++ b/app/jobs/job_kr_tech.py
@@ -59,9 +59,15 @@ def run():
         print(f"[GAME] Meme image generated at {image_path}")
 
     # 7. 워드프레스에 글 발행
+    body_with_source = gpt_utils.append_source_link(
+        body_markdown=post_data["body_markdown"],
+        source_url=picked["url"],
+        link_text=post_data.get("source_link_text", "원문 보기"),
+    )
+
     wp_client.create_post(
         title=post_data["title"],
-        body_markdown=post_data["body_markdown"],
+        body_markdown=body_with_source,
         cynical_comment=post_data["cynical_comment"],
         meme_media_id=media_id,
         category_id=WP_CATEGORY_KR_TECH,

--- a/app/jobs/job_us_tech.py
+++ b/app/jobs/job_us_tech.py
@@ -64,9 +64,15 @@ def run():
         print(f"[GAME] Meme image generated at {image_path}")
         
     # 7. 워드프레스에 글 발행
+    body_with_source = gpt_utils.append_source_link(
+        body_markdown=post_data["body_markdown"],
+        source_url=picked["url"],
+        link_text=post_data.get("source_link_text", "원문 보기"),
+    )
+
     wp_client.create_post(
         title=post_data["title"],
-        body_markdown=post_data["body_markdown"],
+        body_markdown=body_with_source,
         cynical_comment=post_data["cynical_comment"],
         meme_media_id=media_id,
         category_id=WP_CATEGORY_US_TECH,


### PR DESCRIPTION
## Summary
- request GPT for anchor text separately from the article body so summaries stay link-free
- append a standardized HTML source link block using the original URL and GPT-provided link text before publishing
- ensure all posting jobs include the generated source link block

## Testing
- not run (not requested)

Fixes #5 


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949c347bc6c832fbcdfcc1efed982e6)