### PR TITLE
Add English-only text instruction to Gemini image prompts

### DIFF
--- a/app/common/image_utils.py
+++ b/app/common/image_utils.py
@@ -76,7 +76,12 @@ def generate_meme_image(meme_prompt: str, job_prefix: str):
         "contents": [
             {
                 "parts": [
-                    {"text": meme_prompt}
+                    {
+                        "text": (
+                            f"{meme_prompt}\n\n"
+                            "All text that appears inside the image must be in English only."
+                        )
+                    }
                 ]
             }
         ],


### PR DESCRIPTION
## Summary
- append an English-only text instruction to Gemini image generation prompts to constrain on-image text language

## Testing
- not run

Fixes #7 

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949c71108d0832f93e042f80c231b6d)